### PR TITLE
Added to_polar() and to_cartesian() methods to the nrtb common triad template.

### DIFF
--- a/cpp/common/point/common_test.cpp
+++ b/cpp/common/point/common_test.cpp
@@ -54,7 +54,7 @@ int main()
   ld_triad a(1,2,3);
   ld_triad b(3,2,1);
   int returnme = 0;
-/*
+
   cout << setprecision(10);
   cout << "=== nrtb::triad Unit Test ===" << endl;
   cout << "\ta = " << a << "; b = " << b << endl;
@@ -104,70 +104,81 @@ int main()
   returnme = test_triad("b",b,ld_triad(2,3.5,7),returnme);
   returnme = test_triad("b.from_str(b.to_str(10))",
 				  b.from_str(b.to_str(10)),ld_triad(2,3.5,7),returnme);
-*/
+
+  cout << "\tto_polor()/to_cartesian() tests: ";
+  bool cpc_fail{false};
+  
   ld_triad original(1,1,1);
   ld_triad polar(original.to_polar());
   ld_triad cartesian(polar.to_cartesian());
-  cout << original << polar << cartesian << endl;
-
-  original = ld_triad(0,1,1);
-  polar = original.to_polar();
-  cartesian  = polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
-
-  original = ld_triad(1,0,1);
-  polar = original.to_polar();
-  cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
-
-  original = ld_triad(1,1,0);
-  polar = original.to_polar();
-  cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
-
-  //==========
+  if (original.to_str() != cartesian.to_str())
+  {
+    returnme++;
+    cpc_fail = true;
+    cout << "Failure: " << original << " != " << cartesian << endl;
+  };
+    
   
   original = ld_triad(0,0,0);
   polar = original.to_polar();
   cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
+  if (original.to_str() != cartesian.to_str())
+  {
+    returnme++;
+    cpc_fail = true;
+    cout << "Failure: " << original << " != " << cartesian << endl;
+  };
 
   original = ld_triad(1,0,0);
   polar = original.to_polar();
   cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
+  if (original.to_str() != cartesian.to_str())
+  {
+    returnme++;
+    cpc_fail = true;
+    cout << "Failure: " << original << " != " << cartesian << endl;
+  };
 
   original = ld_triad(0,1,0);
   polar = original.to_polar();
   cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
+  if (original.to_str() != cartesian.to_str())
+  {
+    returnme++;
+    cpc_fail = true;
+    cout << "Failure: " << original << " != " << cartesian << endl;
+  };
 
   original = ld_triad(0,0,1);
   polar = original.to_polar();
   cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
-
-  //==========
-  
-  original = ld_triad(0,0,0);
-  polar = original.to_polar();
-  cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
+  if (original.to_str() != cartesian.to_str())
+  {
+    returnme++;
+    cpc_fail = true;
+    cout << "Failure: " << original << " != " << cartesian << endl;
+  };
 
   original = ld_triad(-1,0,0);
   polar = original.to_polar();
   cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
-
-  original = ld_triad(0,-1,0);
-  polar = original.to_polar();
-  cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
+  if (original.to_str() != cartesian.to_str())
+  {
+    returnme++;
+    cpc_fail = true;
+    cout << "Failure: " << original << " != " << cartesian << endl;
+  };
 
   original = ld_triad(0,0,-1);
   polar = original.to_polar();
   cartesian  =polar.to_cartesian();
-  cout << original << polar << cartesian << endl;
+  if (original.to_str() != cartesian.to_str())
+  {
+    returnme++;
+    cpc_fail = true;
+    cout << "Failure: " << original << " != " << cartesian << endl;
+  };
+  cout << (cpc_fail ? "** FAILED" : "PASSED") << endl;
   
   // report errors, if any
   if (returnme)

--- a/cpp/common/point/common_test.cpp
+++ b/cpp/common/point/common_test.cpp
@@ -54,7 +54,7 @@ int main()
   ld_triad a(1,2,3);
   ld_triad b(3,2,1);
   int returnme = 0;
-
+/*
   cout << setprecision(10);
   cout << "=== nrtb::triad Unit Test ===" << endl;
   cout << "\ta = " << a << "; b = " << b << endl;
@@ -104,7 +104,7 @@ int main()
   returnme = test_triad("b",b,ld_triad(2,3.5,7),returnme);
   returnme = test_triad("b.from_str(b.to_str(10))",
 				  b.from_str(b.to_str(10)),ld_triad(2,3.5,7),returnme);
-
+*/
   ld_triad original(1,1,1);
   ld_triad polar(original.to_polar());
   ld_triad cartesian(polar.to_cartesian());
@@ -125,6 +125,50 @@ int main()
   cartesian  =polar.to_cartesian();
   cout << original << polar << cartesian << endl;
 
+  //==========
+  
+  original = ld_triad(0,0,0);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(1,0,0);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(0,1,0);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(0,0,1);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  //==========
+  
+  original = ld_triad(0,0,0);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(-1,0,0);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(0,-1,0);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(0,0,-1);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+  
   // report errors, if any
   if (returnme)
   {

--- a/cpp/common/point/common_test.cpp
+++ b/cpp/common/point/common_test.cpp
@@ -104,11 +104,31 @@ int main()
   returnme = test_triad("b",b,ld_triad(2,3.5,7),returnme);
   returnme = test_triad("b.from_str(b.to_str(10))",
 				  b.from_str(b.to_str(10)),ld_triad(2,3.5,7),returnme);
+
+  ld_triad original(1,1,1);
+  ld_triad polar(original.to_polar());
+  ld_triad cartesian(polar.to_cartesian());
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(0,1,1);
+  polar = original.to_polar();
+  cartesian  = polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(1,0,1);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
+  original = ld_triad(1,1,0);
+  polar = original.to_polar();
+  cartesian  =polar.to_cartesian();
+  cout << original << polar << cartesian << endl;
+
   // report errors, if any
   if (returnme)
   {
-    cerr << "There were " << returnme 
-      << " error(s) found." << endl;
+    cerr << "There were " << returnme << " error(s) found." << endl;
   }
   cout << "=== nrtb::triad Unit Test Complete ===" << endl;
   // return the error count as the exit code

--- a/cpp/common/point/triad.h
+++ b/cpp/common/point/triad.h
@@ -335,7 +335,7 @@ triad<T> triad<T>::to_polar()
   triad<T> returnme;
   returnme.x = magnatude();
   returnme.y = atan2(y, x);
-  returnme.z = atan2(x*x+y*y, z);
+  returnme.z = atan2(sqrt(x*x+y*y), z);
   return returnme;
 };
 

--- a/cpp/common/point/triad.h
+++ b/cpp/common/point/triad.h
@@ -332,7 +332,7 @@ template <class T>
 triad<T> triad<T>::to_polar()
 {
   triad<T> returnme;
-  returnme.x = *this.magnitude();
+  returnme.x = magnatude();
   returnme.y = atan2(y, x);
   returnme.z = atan2(z, y);
   return returnme;

--- a/cpp/common/point/triad.h
+++ b/cpp/common/point/triad.h
@@ -96,6 +96,10 @@ struct triad
   T dot_product(const triad<T> & a);
   /// Returns the vector product of two triads
   triad<T> vector_product(const triad<T> & a);
+  /// Returns this (assumed) cartesian as polar.
+  triad<T> to_polar();
+  /// Returns an (assumed) polar as cartesian.
+  // TODO: Define to_cartesian()
   bool operator == (const triad<T> & a);
   bool operator != (const triad<T> & a);
   /// Loads from a std::string.
@@ -322,6 +326,16 @@ triad<T> triad<T>::vector_product(const triad<T> & a)
   rv.y = (z * a.x) - (x * a.z);
   rv.z = (x * a.y) - (y * a.x);
   return rv;
+};
+
+template <class T>
+triad<T> triad<T>::to_polar()
+{
+  triad<T> returnme;
+  returnme.x = *this.magnitude();
+  returnme.y = atan2(y, x);
+  returnme.z = atan2(z, y);
+  return returnme;
 };
 
 template <class T>

--- a/cpp/common/point/triad.h
+++ b/cpp/common/point/triad.h
@@ -97,6 +97,7 @@ struct triad
   /// Returns the vector product of two triads
   triad<T> vector_product(const triad<T> & a);
   /// Returns this (assumed) cartesian as polar.
+  /// order: Magitude, azimuth, declination
   triad<T> to_polar();
   /// Returns an (assumed) polar as cartesian.
   triad<T> to_cartesian();
@@ -334,7 +335,7 @@ triad<T> triad<T>::to_polar()
   triad<T> returnme;
   returnme.x = magnatude();
   returnme.y = atan2(y, x);
-  returnme.z = atan2(z, y);
+  returnme.z = atan2(x*x+y*y, z);
   return returnme;
 };
 
@@ -342,12 +343,13 @@ template <class T>
 triad<T> triad<T>::to_cartesian()
 {
   triad<T> returnme;
-  returnme.x = cos(y);
-  returnme.y = sin(y);
-  returnme.z = sin(z);
-std::cout << "\n** pre-normal " << returnme << std::endl;
-  returnme = returnme.normalize();
-  returnme *= x;
+  returnme.x = sin(z) * cos(y) * x;
+  returnme.y = sin(z) * sin(y) * x;
+  returnme.z = cos(z) * x;
+  // cleanup
+  returnme.x = returnme.x > 1e-10 ? returnme.x : 0.0;
+  returnme.y = returnme.y > 1e-10 ? returnme.y : 0.0;
+  returnme.z = returnme.z > 1e-10 ? returnme.z : 0.0;
   return returnme;
 };  
 

--- a/cpp/common/point/triad.h
+++ b/cpp/common/point/triad.h
@@ -342,9 +342,12 @@ template <class T>
 triad<T> triad<T>::to_cartesian()
 {
   triad<T> returnme;
-  returnme.x = x * sin(y) * cos(z);
-  returnme.y = x * sin(y) * sin(z);
-  returnme.z = x * cos(y);
+  returnme.x = cos(y);
+  returnme.y = sin(y);
+  returnme.z = sin(z);
+std::cout << "\n** pre-normal " << returnme << std::endl;
+  returnme = returnme.normalize();
+  returnme *= x;
   return returnme;
 };  
 

--- a/cpp/common/point/triad.h
+++ b/cpp/common/point/triad.h
@@ -99,7 +99,7 @@ struct triad
   /// Returns this (assumed) cartesian as polar.
   triad<T> to_polar();
   /// Returns an (assumed) polar as cartesian.
-  // TODO: Define to_cartesian()
+  triad<T> to_cartesian();
   bool operator == (const triad<T> & a);
   bool operator != (const triad<T> & a);
   /// Loads from a std::string.
@@ -337,6 +337,16 @@ triad<T> triad<T>::to_polar()
   returnme.z = atan2(z, y);
   return returnme;
 };
+
+template <class T>
+triad<T> triad<T>::to_cartesian()
+{
+  triad<T> returnme;
+  returnme.x = x * sin(y) * cos(z);
+  returnme.y = x * sin(y) * sin(z);
+  returnme.z = x * cos(y);
+  return returnme;
+};  
 
 template <class T>
 bool triad<T>::operator == (const triad<T> & a)

--- a/cpp/common/point/triad.h
+++ b/cpp/common/point/triad.h
@@ -346,10 +346,10 @@ triad<T> triad<T>::to_cartesian()
   returnme.x = sin(z) * cos(y) * x;
   returnme.y = sin(z) * sin(y) * x;
   returnme.z = cos(z) * x;
-  // cleanup
-  returnme.x = returnme.x > 1e-10 ? returnme.x : 0.0;
-  returnme.y = returnme.y > 1e-10 ? returnme.y : 0.0;
-  returnme.z = returnme.z > 1e-10 ? returnme.z : 0.0;
+  // cleanup really tiny results.
+  returnme.x = fabs(returnme.x) > 1e-10 ? returnme.x : 0.0;
+  returnme.y = fabs(returnme.y) > 1e-10 ? returnme.y : 0.0;
+  returnme.z = fabs(returnme.z) > 1e-10 ? returnme.z : 0.0;
   return returnme;
 };  
 


### PR DESCRIPTION
triad<T>::to_polar() : returns the (assumed) cartesian 3d vector as a polar vector. x is magnitude, y is azimuth, and z is declination.

triad<T>::to_cartesian() : returns the (assumed) polar 3d vector as a cartesian vector. The triad<T> is assumed to be in the polar format produced by the to_polar() method documented above.

Both methods were added to the (...)/cpp/common/point/triad.h template and the unit test for that module has been updated to validate the new methods. Compiles and unit tests cleanly, ready for review and merge to main.