### PR TITLE
Drivebugs -- fixes for issues in the diff_steer effector

### DIFF
--- a/cpp/sim_engine/diff_steer_effector/diff_steer.cpp
+++ b/cpp/sim_engine/diff_steer_effector/diff_steer.cpp
@@ -234,6 +234,7 @@ bool diff_steer::post::tick(base_object& o, float time)
     DoT.z = 0.0;
     // get the current ground speed and direction
     triplet gnd_vec = DoT.to_polar();
+    if (gnd_vec.y < 0.0) gnd_vec.y += 2*pi;
     float delta = fabs(gnd_vec.y - att.z) ;
     // are we sliding?
     if ((gnd_vec.x > 0.0001) and (delta > 0.005))
@@ -243,9 +244,9 @@ bool diff_steer::post::tick(base_object& o, float time)
        * simplistic for alpha.. simply snap to the 
        * current heading.
        *******************************/
-      gnd_vec.y = att.z;
+      gnd_vec.y = att.z; 
       // adjust gspeed to deal with the skid.
-      gnd_vec.x *= 1.0 - pow(delta * (gnd_vec.x/1e4), 2);
+      gnd_vec.x *= 1.0 - pow(delta * (gnd_vec.x/1e4), 3);
       // store the changes back to the object.
       DoT = gnd_vec.to_cartesian();
       o.velocity.x = DoT.x;

--- a/cpp/sim_engine/diff_steer_effector/diff_steer_test.cpp
+++ b/cpp/sim_engine/diff_steer_effector/diff_steer_test.cpp
@@ -202,7 +202,7 @@ int main()
       test_ob.tick(d);
       test_ob.apply(d);
       i++;
-      if (i > 300) break;
+      if (i > 3000) break;
     }; 
     test_failed = (i != 261);
     failed = failed or test_failed;


### PR DESCRIPTION
Corrected issues observed in diff_steer while working with BCP programs:

   * Power and Brake can not be on at the same time. Activating either zeros the other.
   * Turning fast enough to cause a skid now causes ground speed loss relative to the speed and the amount of course deviation.
   * Rolling friction now works and scales with ground speed.